### PR TITLE
open UI in default browser

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ func main() {
 	controllers.Listen(protocol, target)
 
 	fmt.Println("───────────────────────────────────────────────────")
+	fmt.Println("Manager UI is available at \nhttp://still-surf-8123.on.fleek.co.ipns.localhost:8080/")
+	fmt.Println("───────────────────────────────────────────────────")
+	utils.OpenBrowser("https://still-surf-8123.on.fleek.co/")
 
 	// Run with HTTP
 	router.Run("0.0.0.0:" + strconv.FormatUint(uint64(config.Port), 10))

--- a/utils/browser.go
+++ b/utils/browser.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"runtime"
+)
+
+func OpenBrowser(url string) {
+	var err error
+
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("Cannot open link in default browser: unsupported platform")
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
A way to open the UI in the default web browser without the need to click on any link manually.

Should work with MacOS/Windows/Linux distos.